### PR TITLE
Implements Harness Inspection

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,6 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
+uvloop = "*"
 
 [dev-packages]
 pytest = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e0d7048436df1d871ba7b7141c356bf8013d92d94af5534301e7e97102ab812c"
+            "sha256": "3b34079fe27398816be71f7f26b551bd11acca5223d38f7f2305c0b70c67b0e8"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -15,7 +15,24 @@
             }
         ]
     },
-    "default": {},
+    "default": {
+        "uvloop": {
+            "hashes": [
+                "sha256:198fe0c196056930ec6c4a0a878e531a66d15467ca7c74a875aa90271f0c6e3f",
+                "sha256:1c175f47d34b84e33c0e312f4987c927ea004afc3a5f05d2f0f610d71d0e4c89",
+                "sha256:1c47f197be8f0a3c651dd20be1e1bd43268186246f246d4e86c91e95a89e4865",
+                "sha256:3fd4943570d20e8cd4d9f0a3190ebd5cf040e5610b685e05c878128a11f7ad14",
+                "sha256:435e232869923fd2248e4ca0ad73e24a5b4debf40bed9dcde133cfe1bef98a7a",
+                "sha256:9cfdb966ae804c46b96c92207dfd2174935ffc70e706e42e1c94c60d16dbe860",
+                "sha256:a585781443eeb2edb858f8c08c503aac237a5f1bebf0c84ea8340cc337afa408",
+                "sha256:b296493e033846e46488a6aa227a75c790091f5ee5456ec637bb0badad1e8851",
+                "sha256:c684047c6cf6d697ba37872fb1b4489012ea91f3f802c8fbb9c367c4902e88dc",
+                "sha256:da5a59d8812188b57b5783c7fb78891d14dd1050b6259680e0dbd4253d7d0f64"
+            ],
+            "index": "pypi",
+            "version": "==0.12.1"
+        }
+    },
     "develop": {
         "aiofiles": {
             "hashes": [
@@ -111,11 +128,11 @@
         },
         "more-itertools": {
             "hashes": [
-                "sha256:38a936c0a6d98a38bcc2d03fdaaedaba9f412879461dd2ceff8d37564d6522e4",
-                "sha256:c0a5785b1109a6bd7fac76d6837fd1feca158e54e521ccd2ae8bfe393cc9d4fc",
-                "sha256:fe7a7cae1ccb57d33952113ff4fa1bc5f879963600ed74918f1236e212ee50b9"
+                "sha256:0125e8f60e9e031347105eb1682cef932f5e97d7b9a1a28d9bf00c22a5daef40",
+                "sha256:590044e3942351a1bdb1de960b739ff4ce277960f2425ad4509446dbace8d9d1"
             ],
-            "version": "==5.0.0"
+            "markers": "python_version > '2.7'",
+            "version": "==6.0.0"
         },
         "multidict": {
             "hashes": [
@@ -167,11 +184,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:65aeaa77ae87c7fc95de56285282546cfa9c886dc8e5dc78313db1c25e21bc07",
-                "sha256:6ac6d467d9f053e95aaacd79f831dbecfe730f419c6c7022cb316b365cd9199d"
+                "sha256:80cfd9c8b9e93f419abcc0400e9f595974a98e44b6863a77d3e1039961bfc9c4",
+                "sha256:c2396a15726218a2dfef480861c4ba37bd3952ebaaa5b0fede3fc23fddcd7f8c"
             ],
             "index": "pypi",
-            "version": "==4.2.0"
+            "version": "==4.2.1"
         },
         "pytest-cov": {
             "hashes": [
@@ -229,19 +246,19 @@
         },
         "uvloop": {
             "hashes": [
-                "sha256:0ff2e67b693f7d2007466952dbe312075098e8f15364fda27d16e8a7f266d74d",
-                "sha256:2d0029314dc87312ff8d46c3724363d847e5235403eced5d3f98da80a87f4828",
-                "sha256:32dcc003e1973f3db303494f5f63db11091c86a146053773d81ac5484b10c416",
-                "sha256:4301871418f967d0b13409f1bd10ecc7825a7f183282dcc9e19d08532e6cb2e9",
-                "sha256:7639188ff4466d86cfd4418cd784d1198a8cc913279fb8798a4b12a4d42ad341",
-                "sha256:a73649cd043f5d3e3ae471667c790a7ee2295b22fac7bedcae8705158f8ba111",
-                "sha256:afdf34bf507090e4c7f5108a17240982760356b8aae4edd37180ec4f94c36cbb",
-                "sha256:bd7a6db5dbfae0c93e27cb200bb2b9513e21a90a2d4a259b39a9b5446c4d5aa3",
-                "sha256:cc27e903da274f76826848832f62e1ec410a43602e1e0cd4f8db8c619b1ee93e",
-                "sha256:ec521d14ddcdd9f8d0075d7d1f82e9d8806f7f0a047d2e5bc737e9eddf7f930d"
+                "sha256:198fe0c196056930ec6c4a0a878e531a66d15467ca7c74a875aa90271f0c6e3f",
+                "sha256:1c175f47d34b84e33c0e312f4987c927ea004afc3a5f05d2f0f610d71d0e4c89",
+                "sha256:1c47f197be8f0a3c651dd20be1e1bd43268186246f246d4e86c91e95a89e4865",
+                "sha256:3fd4943570d20e8cd4d9f0a3190ebd5cf040e5610b685e05c878128a11f7ad14",
+                "sha256:435e232869923fd2248e4ca0ad73e24a5b4debf40bed9dcde133cfe1bef98a7a",
+                "sha256:9cfdb966ae804c46b96c92207dfd2174935ffc70e706e42e1c94c60d16dbe860",
+                "sha256:a585781443eeb2edb858f8c08c503aac237a5f1bebf0c84ea8340cc337afa408",
+                "sha256:b296493e033846e46488a6aa227a75c790091f5ee5456ec637bb0badad1e8851",
+                "sha256:c684047c6cf6d697ba37872fb1b4489012ea91f3f802c8fbb9c367c4902e88dc",
+                "sha256:da5a59d8812188b57b5783c7fb78891d14dd1050b6259680e0dbd4253d7d0f64"
             ],
-            "markers": "sys_platform != 'win32' and implementation_name == 'cpython'",
-            "version": "==0.12.0"
+            "index": "pypi",
+            "version": "==0.12.1"
         },
         "websockets": {
             "hashes": [

--- a/jab/exceptions.py
+++ b/jab/exceptions.py
@@ -12,3 +12,7 @@ class MissingDependency(Exception):
 
 class InvalidLifecycleMethod(Exception):
     pass
+
+
+class UnknownConstructor(Exception):
+    pass

--- a/jab/harness.py
+++ b/jab/harness.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import uvloop
 from copy import deepcopy
 from inspect import isclass, iscoroutinefunction, isfunction
 from typing import Any, Dict, List, Optional, Tuple
@@ -27,6 +28,8 @@ class Harness:
     """
 
     def __init__(self) -> None:
+        asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+
         self._provided: Dict[str, Any] = {}
         self._dep_graph: Dict[Any, Dict[str, Any]] = {}
         self._env: Dict[str, Any] = {}
@@ -383,6 +386,7 @@ class Harness:
             self._run()
 
         self._on_stop()
+        self._loop.close()
 
 
 def isimplementation(cls_: Any, proto: Any) -> bool:

--- a/jab/harness.py
+++ b/jab/harness.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 from copy import deepcopy
 from inspect import isclass, iscoroutinefunction, isfunction
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import toposort
 from typing_extensions import Protocol, _get_protocol_attrs  # type: ignore
@@ -33,6 +33,24 @@ class Harness:
         self._exec_order: List[str] = []
         self._loop = asyncio.get_event_loop()
         self._logger = DefaultJabLogger()
+
+    def inspect(self) -> Tuple[Dict[str, Any], Dict[Any, Dict[str, Any]]]:
+        """
+        `inspect` allows for introspection of the Harness's environment.
+        This allows for direct access to the objects created and stored in
+        the environment as well as the ability to examine the dependency
+        graph as understood by the harness.
+
+        Returns
+        -------
+        Dict[str, Any]
+            The Harness's environment. A Dictionary of class name keys
+            to instances of that class values.
+        Dict[Any, Dict[str, Any]]
+            The dependenccy graph built after `provide` calls on the
+            harness.
+        """
+        return (deepcopy(self._env), deepcopy(self._dep_graph))
 
     def provide(self, *args: Any) -> Harness:  # NOQA
         """

--- a/jab/harness.py
+++ b/jab/harness.py
@@ -13,8 +13,8 @@ from jab.exceptions import (
     InvalidLifecycleMethod,
     MissingDependency,
     NoAnnotation,
-    UnknownConstructor,
     NoConstructor,
+    UnknownConstructor,
 )
 from jab.inspect import Dependency, Provided
 from jab.logging import DefaultJabLogger, Logger

--- a/jab/harness.py
+++ b/jab/harness.py
@@ -1,20 +1,22 @@
 from __future__ import annotations
 
 import asyncio
-import uvloop
 from copy import deepcopy
 from inspect import isclass, iscoroutinefunction, isfunction
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Type, Union, overload
 
 import toposort
+import uvloop
 from typing_extensions import Protocol, _get_protocol_attrs  # type: ignore
 
 from jab.exceptions import (
     InvalidLifecycleMethod,
     MissingDependency,
     NoAnnotation,
+    UnknownConstructor,
     NoConstructor,
 )
+from jab.inspect import Dependency, Provided
 from jab.logging import DefaultJabLogger, Logger
 
 DEFAULT_LOGGER = "DEFAULT LOGGER"
@@ -37,23 +39,92 @@ class Harness:
         self._loop = asyncio.get_event_loop()
         self._logger = DefaultJabLogger()
 
-    def inspect(self) -> Tuple[Dict[str, Any], Dict[Any, Dict[str, Any]]]:
+    @overload
+    def inspect(self) -> List[Provided]:
+        pass
+
+    @overload  # noqa: F811
+    def inspect(self, arg: Union[Type, Callable]) -> Provided:
+        pass
+
+    def inspect(  # noqa: F811
+        self, arg: Optional[Union[Type, Callable]] = None
+    ) -> Union[List[Provided], Provided]:
         """
         `inspect` allows for introspection of the Harness's environment.
         This allows for direct access to the objects created and stored in
         the environment as well as the ability to examine the dependency
         graph as understood by the harness.
 
+        Parameters
+        ----------
+        arg : Optional[Union[Type, Callable]]
+            Optional argument of either a class or a functional constructor.
+            If no argument is provided, a full inspection record of all
+            provided classes is returned
+
         Returns
         -------
-        Dict[str, Any]
-            The Harness's environment. A Dictionary of class name keys
-            to instances of that class values.
-        Dict[Any, Dict[str, Any]]
-            The dependenccy graph built after `provide` calls on the
-            harness.
+        Union[List[Provided], Provided]
+            The Provided class represents metadata around a provided, constructed
+            class and its dependencies as well as the constructed instance itself.
         """
-        return (deepcopy(self._env), deepcopy(self._dep_graph))
+        if arg:
+            return self._build_inspect(arg)
+
+        return [self._build_inspect(x) for x in self._provided.values()]
+
+    def _build_inspect(self, arg: Any) -> Provided:
+        """
+        `_build_inspect` creates the Provided dataclass for a specific constructor.
+        The function is called recursively on a constructor's depdencies to create
+        the dependecy list.
+
+        Parameters
+        ----------
+        arg : Any
+            The constructor whose inspection record should be generated.
+
+        Returns
+        -------
+        Provided
+            An inspection record of a constructor, its name, its concrete, constructed
+            instance and all of its dependencies.
+
+        Raises
+        ------
+        UnknownConstructor
+            If the provided constructor is unknown to the jab harness, this
+            exception will be raised.
+        """
+        t = arg
+
+        if isfunction(arg):
+            deps = arg.__annotations__
+            t = deps["return"]
+        else:
+            deps = arg.__init__.__annotations__
+
+        name, obj = next(
+            ((name, obj) for name, obj in self._env.items() if isinstance(obj, t)),
+            (None, None),
+        )
+
+        if not name or not obj:
+            raise UnknownConstructor("{} not registered with jab harness".format(arg))
+
+        matched = self._dep_graph[name]
+
+        dependencies = [
+            Dependency(
+                provided=self._build_inspect(self._provided[x]),
+                parameter=p,
+                type=deps[p],
+            )
+            for p, x in matched.items()
+        ]
+
+        return Provided(name=name, constructor=arg, obj=obj, dependencies=dependencies)
 
     def provide(self, *args: Any) -> Harness:  # NOQA
         """

--- a/jab/harness_test.py
+++ b/jab/harness_test.py
@@ -1,12 +1,11 @@
 import asyncio
 from collections import Counter
+from inspect import isfunction
+from typing import get_type_hints
 
 import pytest
 import toposort
-from inspect import isfunction
 from typing_extensions import Protocol
-
-from typing import get_type_hints
 
 import jab
 

--- a/jab/harness_test.py
+++ b/jab/harness_test.py
@@ -3,7 +3,10 @@ from collections import Counter
 
 import pytest
 import toposort
+from inspect import isfunction
 from typing_extensions import Protocol
+
+from typing import get_type_hints
 
 import jab
 
@@ -235,7 +238,16 @@ def test_bad_function() -> None:
 
 
 def test_inspect() -> None:
-    h = jab.Harness().provide(ProvideCounter, NeedsCounter)
-    env, _ = h.inspect()
-    print(env, h._env)
-    assert 0 == 1
+    h = jab.Harness().provide(
+        ProvideCounter, NeedsCounter, NeedsShouter, ProvidesShouter
+    )
+
+    for x in h.inspect():
+        assert x == h.inspect(x.constructor)
+
+        if isfunction(x.constructor):
+            hints = get_type_hints(x.constructor)
+        else:
+            hints = get_type_hints(x.constructor.__init__)
+
+        assert len([x for x in hints.keys() if x != "return"]) == len(x.dependencies)

--- a/jab/harness_test.py
+++ b/jab/harness_test.py
@@ -232,3 +232,10 @@ def test_bad_function() -> None:
 
     with pytest.raises(jab.Exceptions.NoConstructor):
         jab.Harness().provide(bad_func, NeedsCounter)
+
+
+def test_inspect() -> None:
+    h = jab.Harness().provide(ProvideCounter, NeedsCounter)
+    env, _ = h.inspect()
+    print(env, h._env)
+    assert 0 == 1

--- a/jab/inspect.py
+++ b/jab/inspect.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any, List
 
 from dataclasses import dataclass, field

--- a/jab/inspect.py
+++ b/jab/inspect.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import Any, List
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Provided:
+    name: str
+    constructor: Any
+    obj: Any
+    dependencies: List["Dependency"] = field(default_factory=list)
+
+
+@dataclass
+class Dependency:
+    parameter: str
+    type: Any
+    provided: Provided


### PR DESCRIPTION
Implements #7 

Calling `jab.Harness.inspect` on an instantiated harness now returns a detailed explanation of the internal Harness wiring for each registered class and object.

You can also call `jab.Harness.inspect` with a constructor and return an inspection object for just that constructor.