### PR TITLE
Add _jab when a constructor relies on free variables of a closure

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,12 +4,12 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
+toposort = "*"
 uvloop = "*"
 
 [dev-packages]
 pytest = "*"
 typing-extensions = "*"
-toposort = "*"
 black = "*"
 isort = "*"
 pytest-cov = "*"

--- a/example.py
+++ b/example.py
@@ -1,10 +1,11 @@
 from typing import Callable, Dict, List
 
-import jab
 from sanic import Sanic
 from sanic.request import Request
 from sanic.response import HTTPResponse, text
 from typing_extensions import Protocol
+
+import jab
 
 
 class API:

--- a/jab/__init__.py
+++ b/jab/__init__.py
@@ -1,11 +1,11 @@
-from jab.harness import Harness  # NOQA
 from jab.exceptions import (
+    InvalidLifecycleMethod,
+    MissingDependency,
     NoAnnotation,
     NoConstructor,
-    MissingDependency,
-    InvalidLifecycleMethod,
 )
-from jab.logging import Logger, DefaultJabLogger  # NOQA
+from jab.harness import Harness  # NOQA
+from jab.logging import DefaultJabLogger, Logger  # NOQA
 
 
 class Exceptions:

--- a/jab/exceptions.py
+++ b/jab/exceptions.py
@@ -16,3 +16,7 @@ class InvalidLifecycleMethod(Exception):
 
 class UnknownConstructor(Exception):
     pass
+
+
+class DuplicateProvide(Exception):
+    pass

--- a/jab/harness.py
+++ b/jab/harness.py
@@ -17,6 +17,7 @@ from typing import (
 import toposort
 import uvloop
 from jab.exceptions import (
+    DuplicateProvide,
     InvalidLifecycleMethod,
     MissingDependency,
     NoAnnotation,
@@ -157,6 +158,13 @@ class Harness:
                         name = free_var.cell_contents._jab
                     except AttributeError:
                         pass
+
+            if self._provided.get(name):
+                raise DuplicateProvide(
+                    'Cannot provide object {} under name "{}". Name is already taken by object {}'.format(
+                        arg, name, self._provided[name]
+                    )
+                )
 
             self._provided[name] = arg
 

--- a/jab/harness.py
+++ b/jab/harness.py
@@ -16,8 +16,6 @@ from typing import (
 
 import toposort
 import uvloop
-from typing_extensions import Protocol, _get_protocol_attrs  # type: ignore
-
 from jab.exceptions import (
     DuplicateProvide,
     InvalidLifecycleMethod,
@@ -28,6 +26,7 @@ from jab.exceptions import (
 )
 from jab.inspect import Dependency, Provided
 from jab.logging import DefaultJabLogger, Logger
+from typing_extensions import Protocol, _get_protocol_attrs  # type: ignore
 
 DEFAULT_LOGGER = "DEFAULT LOGGER"
 

--- a/jab/harness.py
+++ b/jab/harness.py
@@ -123,10 +123,14 @@ class Harness:
         else:
             deps = get_type_hints(arg.__init__)
 
-        name, obj = next(
-            ((name, obj) for name, obj in self._env.items() if isinstance(obj, t)),
-            (None, None),
-        )
+        if isinstance(t, str):
+            name: Optional[str] = t
+            obj: Any = self._env[t]
+        else:
+            name, obj = next(
+                ((name, obj) for name, obj in self._env.items() if isinstance(obj, t)),
+                (None, None),
+            )
 
         if not name or not obj:
             raise UnknownConstructor(f"{arg} not registered with jab harness")

--- a/jab/harness.py
+++ b/jab/harness.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from inspect import isclass, iscoroutinefunction, isfunction
+from inspect import isclass, iscoroutinefunction, isfunction, ismethod
 from typing import (
     Any,
     Callable,
@@ -328,11 +328,18 @@ class Harness:
         _is_func = False
         if not isclass(arg):
             if not isfunction(arg):
-                raise NoConstructor(
-                    "Provided argument '{}' does not have a constructor function".format(
-                        str(arg)
-                    )
+                msg = "Provided argument '{}' not have a constructor function.".format(
+                    str(arg)
                 )
+                if ismethod(arg):
+                    if get_type_hints(arg)["return"] == Callable:
+                        raise NoConstructor(
+                            msg
+                            + " But it is a method that returns a possible constructor function."
+                            + " Consider adding a @property decorator."
+                        )
+
+                raise NoConstructor(msg)
             else:
                 _is_func = True
                 deps = get_type_hints(arg)

--- a/jab/harness.py
+++ b/jab/harness.py
@@ -16,6 +16,8 @@ from typing import (
 
 import toposort
 import uvloop
+from typing_extensions import Protocol, _get_protocol_attrs  # type: ignore
+
 from jab.exceptions import (
     DuplicateProvide,
     InvalidLifecycleMethod,
@@ -26,7 +28,6 @@ from jab.exceptions import (
 )
 from jab.inspect import Dependency, Provided
 from jab.logging import DefaultJabLogger, Logger
-from typing_extensions import Protocol, _get_protocol_attrs  # type: ignore
 
 DEFAULT_LOGGER = "DEFAULT LOGGER"
 
@@ -111,6 +112,14 @@ class Harness:
         if isfunction(arg):
             deps = get_type_hints(arg)
             t = deps["return"]
+
+            closures = arg.__closure__ or []
+            for free_var in closures:
+                try:
+                    t = free_var.cell_contents._jab
+                except AttributeError:
+                    pass
+
         else:
             deps = get_type_hints(arg.__init__)
 

--- a/jab/harness_test.py
+++ b/jab/harness_test.py
@@ -3,10 +3,11 @@ from collections import Counter
 from inspect import isfunction
 from typing import get_type_hints
 
-import jab
 import pytest
 import toposort
 from typing_extensions import Protocol
+
+import jab
 
 
 class NumberProvider(Protocol):

--- a/jab/inspect.py
+++ b/jab/inspect.py
@@ -1,5 +1,6 @@
-from dataclasses import dataclass, field
 from typing import Any, List
+
+from dataclasses import dataclass, field
 
 
 @dataclass

--- a/jab/inspect.py
+++ b/jab/inspect.py
@@ -1,6 +1,5 @@
-from typing import Any, List
-
 from dataclasses import dataclass, field
+from typing import Any, List
 
 
 @dataclass


### PR DESCRIPTION
## Motivating Example

```python
from __future__ import annotations

from typing import Callable

import asyncio
import jab


class RunEvery:
    def __init__(self, fn: Callable, seconds: int) -> None:
        self._jab = "RunEvery.{}.{}".format(
            fn.__name__,
            seconds,
        )
        self.fn = fn
        self.seconds = seconds

    async def run(self) -> None:
        while True:
            print("Running {}".format(self._jab))
            self.fn()
            await asyncio.sleep(self.seconds)

    @property
    def jab(self) -> Callable:
        def constructor() -> RunEvery:
            return self

        return constructor


def print_name() -> None:
    print("stntngo")


run_every_five = RunEvery(print_name, 5)
run_every_one = RunEvery(print_name, 1)


jab.Harness().provide(
    run_every_five.jab,
    run_every_one.jab,
).run()
```

Let's say, like in the example above, you decide to take advantage of closures to provide two instances of the same class to a jab Harness. This makes sense because each instance is doing a different kind of work, `run_every_five` is using `RunEvery` to do something every five seconds and `run_every_one` is using `RunEvery` to do something every second. This same sort of closure manipulation of an existing instance as already an option with jab, but without the `_jab` flag defined inside of `RunEvery` or the changes made in this PR providing two such closures that themselves provide the same class would cause the second closure to overwrite the first inside of the harness's internal environment.

### Why @property?

Using the `@property` decorator instead of rewriting the `jab` method something like

```python
class RunEvery:

# ...

    def jab(self) -> RunEvery:
        return self
```

makes it more difficult to pass in an unbound method to the jab harness and create issues. It also creates a common means of defining these instantiated closure providers in such a way that the `jab` property can possibly access uninstantiated classes that have been passed into it, alter the inner functions annotations to include those classes' dependencies as dependencies of its own runtime created constructor, and then provide that new constructor definition to the jab harness.