### PR TITLE
Implement `jab.closure` decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ jab.Harness().provide(...other_deps, pool.jab).run()
 
 ```
 
-The decorator will take care of creating the `PostgresPool.jab` method as well as creating a unique `PostgresPool._jab` value for each individual instance, ensuring that multiple instances of the same class can be passed into a jab harness and that each instance may only pass itself into the jab harness once.
+The decorator will take care of creating the `PostgresPool.jab` property method as well as creating a unique `PostgresPool._jab` value for each individual instance, ensuring that multiple instances of the same class can be passed into a jab harness and that each instance may only pass itself into the jab harness once.
 
 ### Lifecycle Methods
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 💉  jab ![jab-version](https://img.shields.io/badge/version-0.3.0-orange.svg) ![py-version](https://img.shields.io/badge/python-3.7-blue.svg) ![codecov](https://img.shields.io/badge/coverage-83%25-yellowgreen.svg)
+# 💉  jab ![jab-version](https://img.shields.io/badge/version-0.3.0-orange.svg) ![py-version](https://img.shields.io/badge/python-3.7-blue.svg) ![codecov](https://img.shields.io/badge/coverage-85%25-yellowgreen.svg)
 ###### A Python Dependency Injection Framework
 
 `jab` is heavily inspired by [uber-go/fx](https://github.com/uber-go/fx).
@@ -113,6 +113,25 @@ jab.Harness().provide(...other_deps, pool.jab).run()
 ```
 
 Note the `_jab` attribute of PostgresPool from above. When defining a class that will have a closure constructor method and you are planning to provide multiple instances of the same class to the jab harness the `_jab` attribute will allow two instances of the same class to co-exist under different names so long as their `_jab` attributes are different.
+
+While it is always an option to declare your closure provider yourself, `jab` exposes a convenient decorator to wrap your classes in to make things easier. The example above could further be written as:
+
+```pyton
+@jab.closure
+class PostgresPool:
+    def __init__(self, dsn: str) -> None:
+    	self._jab = dsn
+        self.dsn = dsn
+	self.connection = self.connect()
+
+
+pool = PostgresPool("postgres://localhost")
+
+jab.Harness().provide(...other_deps, pool.jab).run()
+
+```
+
+The decorator will take care of creating the `PostgresPool.jab` method as well as creating a unique `PostgresPool._jab` value for each individual instance, ensuring that multiple instances of the same class can be passed into a jab harness and that each instance may only pass itself into the jab harness once.
 
 ### Lifecycle Methods
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 💉  jab ![jab-version](https://img.shields.io/badge/version-0.3.0-orange.svg) ![py-version](https://img.shields.io/badge/python-3.7-blue.svg) ![codecov](https://img.shields.io/badge/coverage-85%25-yellowgreen.svg)
+# 💉  jab ![jab-version](https://img.shields.io/badge/version-0.3.1-orange.svg) ![py-version](https://img.shields.io/badge/python-3.7-blue.svg) ![codecov](https://img.shields.io/badge/coverage-85%25-yellowgreen.svg)
 ###### A Python Dependency Injection Framework
 
 `jab` is heavily inspired by [uber-go/fx](https://github.com/uber-go/fx).

--- a/example.py
+++ b/example.py
@@ -21,18 +21,15 @@ class API:
 
     async def asgi(self, scope: dict, receive: jab.Receive, send: jab.Send) -> None:
         print(scope)
-        await send({
-            'type': 'http.response.start',
-            'status': 200,
-            'headers': [
-                [b'content-type', b'text/plain'],
-            ]
-        })
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [[b"content-type", b"text/plain"]],
+            }
+        )
 
-        await send({
-            'type': 'http.response.body',
-            'body': b'Hello, world!\n',
-        })
+        await send({"type": "http.response.body", "body": b"Hello, world!\n"})
         return
 
 

--- a/jab/__init__.py
+++ b/jab/__init__.py
@@ -3,10 +3,12 @@ from jab.exceptions import (
     MissingDependency,
     NoAnnotation,
     NoConstructor,
+    DuplicateProvide
 )
 from jab.harness import Harness  # NOQA
 from jab.logging import DefaultJabLogger, Logger  # NOQA
 from jab.asgi import Receive, Send, Handler  # NOQA
+from jab.closures import closure  # NOQA
 
 
 class Exceptions:
@@ -14,3 +16,4 @@ class Exceptions:
     NoConstructor = NoConstructor
     MissingDependency = MissingDependency
     InvalidLifecycleMethod = InvalidLifecycleMethod
+    DuplicateProvide = DuplicateProvide

--- a/jab/__init__.py
+++ b/jab/__init__.py
@@ -3,7 +3,7 @@ from jab.exceptions import (
     MissingDependency,
     NoAnnotation,
     NoConstructor,
-    DuplicateProvide
+    DuplicateProvide,
 )
 from jab.harness import Harness  # NOQA
 from jab.logging import DefaultJabLogger, Logger  # NOQA

--- a/jab/asgi.py
+++ b/jab/asgi.py
@@ -1,4 +1,5 @@
 from typing import Awaitable, Callable
+
 from typing_extensions import Protocol
 
 Receive = Callable[[], Awaitable[dict]]

--- a/jab/closure_test.py
+++ b/jab/closure_test.py
@@ -1,5 +1,6 @@
 from inspect import isfunction
 from typing import get_type_hints
+from dataclasses import dataclass
 import jab
 import pytest
 
@@ -43,3 +44,18 @@ def test_closure_jab_flag():
 
     with pytest.raises(jab.Exceptions.DuplicateProvide):
         jab.Harness().provide(y.jab, y.jab)
+
+
+def test_play_well_with_others():
+
+    @jab.closure
+    @dataclass
+    class User:
+        name: str
+        email: str
+        password: str
+
+    user_one = User(name="Dave", email="hal@9000.net", password="imsorry")
+
+    assert user_one is user_one.jab()
+    assert user_one.name == "Dave"

--- a/jab/closure_test.py
+++ b/jab/closure_test.py
@@ -1,0 +1,45 @@
+from inspect import isfunction
+from typing import get_type_hints
+import jab
+import pytest
+
+
+@jab.closure
+class SampleClass:
+    def __init__(self, name: str) -> None:
+        self._name = name
+
+    def get_name(self) -> str:
+        return self._name
+
+
+def test_closure_func():
+    t = SampleClass("stntngo")
+    assert isfunction(t.jab)
+
+
+def test_closure_return():
+    u = SampleClass("stntngo")
+    assert get_type_hints(u.jab)["return"] == SampleClass
+
+
+def test_closure_pass():
+    v = SampleClass("stntngo")
+    s = v.jab()
+
+    assert s.get_name() == "stntngo"
+    assert s is v
+
+
+def test_closure_jab_flag():
+    a = SampleClass("stntngo")
+    b = a.jab()
+
+    x = SampleClass("stntngo")
+    y = x.jab()
+
+    assert b._jab != y._jab
+    assert b is not y
+
+    with pytest.raises(jab.Exceptions.DuplicateProvide):
+        jab.Harness().provide(y.jab, y.jab)

--- a/jab/closure_test.py
+++ b/jab/closure_test.py
@@ -1,8 +1,10 @@
 from inspect import isfunction
 from typing import get_type_hints
-from dataclasses import dataclass
-import jab
+
 import pytest
+
+import jab
+from dataclasses import dataclass
 
 
 @jab.closure
@@ -47,7 +49,6 @@ def test_closure_jab_flag():
 
 
 def test_play_well_with_others():
-
     @jab.closure
     @dataclass
     class User:

--- a/jab/closures.py
+++ b/jab/closures.py
@@ -1,0 +1,29 @@
+from typing import Callable, Type, Any
+from typing_extensions import Protocol
+
+
+class Instance(Protocol):
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        pass
+
+
+def closure(cls_: Type) -> Type:
+    """
+    `closure` provides a decorator for adding a `jab` property method to a class
+    as well as for ensuring that multiple instances of that class can be provided
+    to the jab harness by ensuring a unique `_jab` attribute id for each instance.
+    """
+
+    def _closure(self: Instance) -> Callable[[], Instance]:
+        ident = f"{type(self).__name__}-{id(self)}"
+        self.__setattr__("_jab", ident)
+
+        def inner():
+            return self
+
+        inner.__annotations__["return"] = type(self)
+        return inner
+
+    setattr(cls_, "jab", property(_closure))
+    return cls_

--- a/jab/closures.py
+++ b/jab/closures.py
@@ -1,9 +1,9 @@
-from typing import Callable, Type, Any
+from typing import Any, Callable, Type
+
 from typing_extensions import Protocol
 
 
 class Instance(Protocol):
-
     def __setattr__(self, name: str, value: Any) -> None:
         pass
 

--- a/jab/harness.py
+++ b/jab/harness.py
@@ -18,7 +18,7 @@ import toposort
 import uvloop
 from typing_extensions import Protocol
 
-from jab.asgi import Send, Receive, Handler, EventHandler
+from jab.asgi import EventHandler, Handler, Receive, Send
 from jab.exceptions import (
     DuplicateProvide,
     InvalidLifecycleMethod,
@@ -547,14 +547,12 @@ class Harness:
                 return
 
     def _asgi_http(self, scope: dict) -> Handler:
-
         async def handler(receive: Receive, send: Send) -> None:
             await self._asgi_handler.asgi(scope, receive, send)
 
         return handler
 
     def _asgi_ws(self, scope: dict) -> Handler:
-
         async def handler(receive: Receive, send: Send) -> None:
             await self._asgi_handler.asgi(scope, receive, send)
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from distutils.core import setup
 if not (sys.version_info.major >= 3 and sys.version_info.minor >= 7):
     raise Exception("jab only works with Python 3.7+")
 
-VERSION = "0.3.0"
+VERSION = "0.3.1"
 
 DEPENDENCIES = ["typing_extensions", "toposort", "uvloop"]
 


### PR DESCRIPTION
The `jab.closure` decorator can be wrapped around any class to provide a `{class}.jab` property method that can be used to provide an instance of the class to a jab harness.